### PR TITLE
Add docker compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,19 @@ Make sure to install the dependencies
 yarn install
 ```
 
+### Environmnet Variables
+
+```plain
+DB_URL=
+BASE_URL=http://localhost:3000
+API_BASE=api/v1/
+JWT_SECRET=
+JWT_EXPIRE=1d
+JWT_COOKIE_EXPIRE=1
+FROM_NAME=YRL Consulting
+FROM_EMAIL=support@yrlus.com
+```
+
 ## Development
 
 Start the development server on http://localhost:3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "3.9"
+services:
+  mongo_db:
+    image: mongo:latest
+    ports:
+      - 27017:27017

--- a/readme
+++ b/readme
@@ -1,8 +1,0 @@
-DB_URL=
-BASE_URL=http://localhost:3000
-API_BASE=api/v1/
-JWT_SECRET=
-JWT_EXPIRE=1d
-JWT_COOKIE_EXPIRE=1
-FROM_NAME=YRL Consulting
-FROM_EMAIL=support@yrlus.com


### PR DESCRIPTION
Docker configuration for running a local mongodb container.

If you want to use this you will need to install [docker](https://www.docker.com/) which requires an account.

This uses the latest [mongo docker image](https://hub.docker.com/_/mongo)