### PR TITLE
Add an editorconfig to standardize code style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
Requires the [editorconfig](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig) vscode extension to apply to new code.